### PR TITLE
Close the issues a release says it resolves

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,10 @@ That form is the whole of the contract, and everything looser is deliberately le
 | `- Fixed it. Related: #123` | no | same - a mention is not a delivery |
 | `- Fixed it (Cratis/Screenplay#32)` | no | another repository's, out of token reach |
 
+A reference inside code - a fenced example, or an inline mention of the syntax itself - is being shown rather
+than made, and is not read. These very notes are the reason: they document the form by writing it out, and the
+number in that example belongs to an unrelated issue.
+
 An issue that is already closed is left exactly as it was, and a number that turns out to be a pull request is
 skipped - a release does not close a pull request.
 

--- a/README.md
+++ b/README.md
@@ -140,8 +140,45 @@ permissions:
 If your organization or repository defaults workflow permissions to read-only (the recommended hardening),
 a workflow with no `permissions:` block cannot create the release and the run fails with a 403 - so declare
 it explicitly rather than relying on the default. The action reads everything else it needs (pull requests,
-releases, tags) through this same token; no extra scopes are required. Reading is done entirely through the
-GitHub API, so no `fetch-depth` or tag checkout is needed.
+releases, tags) through this same token. Reading is done entirely through the GitHub API, so no `fetch-depth`
+or tag checkout is needed.
+
+Closing resolved issues additionally needs `issues: write`:
+
+```yaml
+permissions:
+  contents: write
+  issues: write
+```
+
+Without it the release is still created; the action logs a warning per issue it could not close and carries on,
+because a release that succeeded must never be reported as a failed run. Set `close-resolved-issues: false` to
+turn the behavior off instead of granting the scope.
+
+## Closing the issues a release resolves
+
+When the release notes say a release delivers an issue, the action closes that issue and comments with the
+release tag.
+
+Only the trailing parenthesized form is read - a note bullet **ending** in `(#123)`:
+
+```markdown
+## Fixed
+
+- Roles declared with the constructor form are read (#2381)
+```
+
+That form is the whole of the contract, and everything looser is deliberately left alone:
+
+| Written as | Read? | Why |
+| ---------- | ----- | --- |
+| `- Fixed it (#123)` | yes | the bullet says the release delivers it |
+| `- Fixed it, see #123` | no | prose refers to an issue, it does not deliver it |
+| `- Fixed it. Related: #123` | no | same - a mention is not a delivery |
+| `- Fixed it (Cratis/Screenplay#32)` | no | another repository's, out of token reach |
+
+An issue that is already closed is left exactly as it was, and a number that turns out to be a pull request is
+skipped - a release does not close a pull request.
 
 ## Choosing a trigger
 
@@ -185,6 +222,7 @@ default. Pass a real version to force a release; pass `release-notes` too, or Gi
 | major-labels | Comma-separated label names that mean a major version bump. | `major` | - |
 | minor-labels | Comma-separated label names that mean a minor version bump. | `minor` | - |
 | patch-labels | Comma-separated label names that mean a patch version bump. | `patch` | - |
+| close-resolved-issues | Whether to close the issues the release notes name as resolved. Needs `issues: write`. | `true` | - |
 
 ## Outputs
 

--- a/Source/HandleRelease.ts
+++ b/Source/HandleRelease.ts
@@ -1,8 +1,10 @@
 import { IActionContext } from './IActionContext';
+import { IIssues } from './IIssues';
 import { ILogger } from './ILogger';
 import { IReleaseDecisions } from './IReleaseDecisions';
 import { IReleases } from './IReleases';
 import { ReleaseDecision } from './ReleaseDecision';
+import { ResolvedIssues } from './ResolvedIssues';
 
 /**
  * The post step of the action. Creates the GitHub release for the decision the main step recorded.
@@ -15,8 +17,10 @@ export class HandleRelease {
     constructor(
         readonly _releases: IReleases,
         readonly _decisions: IReleaseDecisions,
+        readonly _issues: IIssues,
         readonly _context: IActionContext,
-        readonly _logger: ILogger) {
+        readonly _logger: ILogger,
+        readonly _closeResolvedIssues: boolean = true) {
     }
 
     async run(): Promise<void> {
@@ -63,5 +67,42 @@ export class HandleRelease {
         });
 
         this._logger.info('GitHub release created.');
+
+        await this.closeResolvedIssues(decision);
+    }
+
+    /**
+     * Closes the issues the release notes say this release resolves.
+     *
+     * Done after the release exists, and never allowed to fail the step. The release is the thing that had to
+     * happen; an issue left open because the API refused is a tidiness problem, while a step that fails after
+     * publishing makes the run look as though nothing shipped.
+     */
+    private async closeResolvedIssues(decision: ReleaseDecision): Promise<void> {
+        if (!this._closeResolvedIssues) {
+            return;
+        }
+
+        const resolved = ResolvedIssues.in(decision.releaseNotes);
+        if (resolved.length === 0) {
+            return;
+        }
+
+        this._logger.info(`The release notes name ${resolved.length} issue(s) as resolved: ${resolved.map(_ => `#${_}`).join(', ')}.`);
+
+        for (const issue of resolved) {
+            try {
+                const closed = await this._issues.close(
+                    issue,
+                    `Closed by release **${decision.tag}**.`);
+
+                if (closed) {
+                    this._logger.info(`Closed #${issue}.`);
+                }
+            } catch (ex) {
+                this._logger.warn(`Could not close #${issue} - leaving it open.`);
+                this._logger.warn(ex);
+            }
+        }
     }
 }

--- a/Source/IInputs.ts
+++ b/Source/IInputs.ts
@@ -7,4 +7,9 @@ export interface IInputs extends IReleaseOptions {
     readonly gitHubToken: string;
     readonly version: string;
     readonly releaseNotes: string;
+
+    /**
+     * Whether to close the issues the release notes name as resolved.
+     */
+    readonly closeResolvedIssues: boolean;
 }

--- a/Source/IIssues.ts
+++ b/Source/IIssues.ts
@@ -1,0 +1,12 @@
+/**
+ * Defines the issues of the repository the action is running for.
+ */
+export interface IIssues {
+    /**
+     * Closes an issue and says why, doing nothing when it is already closed.
+     * @param number The number of the issue to close.
+     * @param comment The comment to leave before closing.
+     * @returns Whether the issue was closed by this call.
+     */
+    close(number: number, comment: string): Promise<boolean>;
+}

--- a/Source/Issues.ts
+++ b/Source/Issues.ts
@@ -1,0 +1,37 @@
+import { Octokit } from '@octokit/rest';
+
+import { IActionContext } from './IActionContext';
+import { IIssues } from './IIssues';
+import { ILogger } from './ILogger';
+
+export class Issues implements IIssues {
+
+    constructor(
+        readonly _octokit: Octokit,
+        readonly _context: IActionContext,
+        readonly _logger: ILogger) {
+    }
+
+    async close(number: number, comment: string): Promise<boolean> {
+        const { owner, repo } = this._context.repo;
+
+        // Asked for first so that an issue somebody already closed by hand is left exactly as they left it,
+        // rather than gaining a comment saying a release closed it. A pull request shares the issue number
+        // space and is excluded for the same reason - a release does not close a pull request.
+        const existing = await this._octokit.rest.issues.get({ owner, repo, issue_number: number });
+        if (existing.data.state !== 'open') {
+            this._logger.info(`Issue #${number} is already closed - leaving it alone.`);
+            return false;
+        }
+
+        if (existing.data.pull_request) {
+            this._logger.info(`#${number} is a pull request rather than an issue - leaving it alone.`);
+            return false;
+        }
+
+        await this._octokit.rest.issues.createComment({ owner, repo, issue_number: number, body: comment });
+        await this._octokit.rest.issues.update({ owner, repo, issue_number: number, state: 'closed', state_reason: 'completed' });
+
+        return true;
+    }
+}

--- a/Source/ResolvedIssues.ts
+++ b/Source/ResolvedIssues.ts
@@ -1,0 +1,43 @@
+/**
+ * The issue numbers a set of release notes says the release resolves.
+ *
+ * Only the trailing parenthesized form the pull request template mandates is read - a bullet ends with the issue
+ * it delivers, as in `- Fixed the thing (#123)`. Prose refers to issues without parentheses ("see #123", "related
+ * to #123", "blocked on #123"), and reading those would close issues a release merely mentions. The parentheses
+ * are what distinguishes "this bullet delivers that issue" from "this bullet talks about it", so they are the
+ * whole of the contract and nothing looser is accepted.
+ *
+ * Cross-repository references (`Cratis/Screenplay#32`) are deliberately not read. They are common in these notes
+ * and they name an issue in another repository, which this action has neither the token scope nor the business to
+ * close.
+ */
+export class ResolvedIssues {
+
+    // A '#' preceded by anything other than '(' is prose, and an owner/repo prefix makes it another repository's
+    // issue. Both are excluded by requiring the '(' to sit immediately before the '#'.
+    private static readonly reference = /(?<![\w/-])\(#(\d+)\)/g;
+
+    /**
+     * Gets the issue numbers the notes say the release resolves, in ascending order and without duplicates.
+     * @param notes The release notes to read.
+     * @returns The issue numbers.
+     */
+    static in(notes: string): number[] {
+        if (!notes) {
+            return [];
+        }
+
+        const found = new Set<number>();
+        for (const match of notes.matchAll(ResolvedIssues.reference)) {
+            const number = Number(match[1]);
+
+            // '(#0)' is not an issue, and a number this large is a typo rather than a reference - closing on
+            // either would act on something the author did not name.
+            if (Number.isSafeInteger(number) && number > 0) {
+                found.add(number);
+            }
+        }
+
+        return [...found].sort((left, right) => left - right);
+    }
+}

--- a/Source/ResolvedIssues.ts
+++ b/Source/ResolvedIssues.ts
@@ -17,6 +17,13 @@ export class ResolvedIssues {
     // issue. Both are excluded by requiring the '(' to sit immediately before the '#'.
     private static readonly reference = /(?<![\w/-])\(#(\d+)\)/g;
 
+    // Release notes carry code - a fenced example of a workflow, an inline mention of the very syntax this class
+    // reads. A reference written inside either is being shown, not made, and closing on it would close whatever
+    // issue the example's number happens to name. The notes of this feature's own release are the proof: they
+    // document the form by writing `(#123)`, and #123 in this repository is an unrelated dependency bump.
+    private static readonly fencedCode = /^[ \t]*(`{3,}|~{3,})[\s\S]*?^[ \t]*\1[ \t]*$/gm;
+    private static readonly inlineCode = /(`+)[^\n]*?\1/g;
+
     /**
      * Gets the issue numbers the notes say the release resolves, in ascending order and without duplicates.
      * @param notes The release notes to read.
@@ -27,8 +34,12 @@ export class ResolvedIssues {
             return [];
         }
 
+        const prose = notes
+            .replace(ResolvedIssues.fencedCode, '')
+            .replace(ResolvedIssues.inlineCode, '');
+
         const found = new Set<number>();
-        for (const match of notes.matchAll(ResolvedIssues.reference)) {
+        for (const match of prose.matchAll(ResolvedIssues.reference)) {
             const number = Number(match[1]);
 
             // '(#0)' is not an issue, and a number this large is a typo rather than a reference - closing on

--- a/Source/for_HandleRelease/when_running/with_a_decision_that_has_release_notes.ts
+++ b/Source/for_HandleRelease/when_running/with_a_decision_that_has_release_notes.ts
@@ -4,6 +4,7 @@ import { HandleRelease } from '../../HandleRelease';
 import { Release } from '../../Release';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
+import { someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
 
@@ -16,6 +17,7 @@ describe('when running the post step with a decision that has release notes', ()
         await new HandleRelease(
             releases,
             aRecordedDecision(aDecisionToRelease({ releaseNotes: 'The actual notes' })),
+            someIssues(),
             anActionContext(),
             new RecordingLogger()).run();
 

--- a/Source/for_HandleRelease/when_running/with_a_decision_to_create_a_release.ts
+++ b/Source/for_HandleRelease/when_running/with_a_decision_to_create_a_release.ts
@@ -4,6 +4,7 @@ import { HandleRelease } from '../../HandleRelease';
 import { Release } from '../../Release';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
+import { someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
 
@@ -17,6 +18,7 @@ describe('when running the post step with a decision to create a release', () =>
         await new HandleRelease(
             releases,
             aRecordedDecision(aDecisionToRelease()),
+            someIssues(),
             anActionContext(),
             new RecordingLogger()).run();
 

--- a/Source/for_HandleRelease/when_running/with_a_decision_without_release_notes.ts
+++ b/Source/for_HandleRelease/when_running/with_a_decision_without_release_notes.ts
@@ -4,6 +4,7 @@ import { HandleRelease } from '../../HandleRelease';
 import { Release } from '../../Release';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
+import { someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
 
@@ -17,6 +18,7 @@ describe('when running the post step with a decision that has no release notes',
         await new HandleRelease(
             releases,
             aRecordedDecision(aDecisionToRelease({ releaseNotes: '' })),
+            someIssues(),
             anActionContext(),
             new RecordingLogger()).run();
 

--- a/Source/for_HandleRelease/when_running/with_a_release_that_already_exists_for_the_commit.ts
+++ b/Source/for_HandleRelease/when_running/with_a_release_that_already_exists_for_the_commit.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from 'vitest';
 import { HandleRelease } from '../../HandleRelease';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
+import { someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
 
@@ -18,6 +19,7 @@ describe('when running the post step for a commit that has already been released
         await new HandleRelease(
             releases,
             aRecordedDecision(aDecisionToRelease()),
+            someIssues(),
             anActionContext(),
             new RecordingLogger()).run();
     });

--- a/Source/for_HandleRelease/when_running/with_a_release_that_already_exists_for_the_tag.ts
+++ b/Source/for_HandleRelease/when_running/with_a_release_that_already_exists_for_the_tag.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from 'vitest';
 import { HandleRelease } from '../../HandleRelease';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
+import { someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
 
@@ -16,6 +17,7 @@ describe('when running the post step for a version that has already been release
         await new HandleRelease(
             releases,
             aRecordedDecision(aDecisionToRelease()),
+            someIssues(),
             anActionContext(),
             new RecordingLogger()).run();
     });

--- a/Source/for_HandleRelease/when_running/with_an_issue_that_cannot_be_closed.ts
+++ b/Source/for_HandleRelease/when_running/with_an_issue_that_cannot_be_closed.ts
@@ -1,0 +1,41 @@
+import sinon from 'sinon';
+import { beforeEach, describe, it } from 'vitest';
+
+import { HandleRelease } from '../../HandleRelease';
+import { RecordingLogger } from '../../specs/RecordingLogger';
+import { anActionContext } from '../../specs/anActionContext';
+import { StubbedIssues, someIssues } from '../../specs/someIssues';
+import { StubbedReleases, someReleases } from '../../specs/someReleases';
+import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
+
+/**
+ * The release is the thing that had to happen. An issue left open because the API refused is untidy; a step that
+ * fails after publishing makes the run look as though nothing shipped, which is worse and is what people act on.
+ */
+describe('when running the post step with an issue that cannot be closed', () => {
+    let issues: StubbedIssues;
+    let releases: StubbedReleases;
+
+    beforeEach(async () => {
+        issues = someIssues();
+        issues.close = sinon.stub();
+        issues.close.onFirstCall().rejects(new Error('Forbidden'));
+        issues.close.onSecondCall().resolves(true);
+        releases = someReleases();
+
+        await new HandleRelease(
+            releases,
+            aRecordedDecision(aDecisionToRelease({ releaseNotes: '- One (#123)\n- Two (#456)' })),
+            issues,
+            anActionContext(),
+            new RecordingLogger()).run();
+    });
+
+    it('should not fail the step', () => {
+        releases.create.calledOnce.should.be.true;
+    });
+
+    it('should still close the issues it can', () => {
+        issues.close.callCount.should.equal(2);
+    });
+});

--- a/Source/for_HandleRelease/when_running/with_closing_resolved_issues_turned_off.ts
+++ b/Source/for_HandleRelease/when_running/with_closing_resolved_issues_turned_off.ts
@@ -3,25 +3,32 @@ import { beforeEach, describe, it } from 'vitest';
 import { HandleRelease } from '../../HandleRelease';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
-import { someIssues } from '../../specs/someIssues';
+import { StubbedIssues, someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
 
-describe('when running the post step with a decision not to create a release', () => {
+describe('when running the post step with closing resolved issues turned off', () => {
+    let issues: StubbedIssues;
     let releases: StubbedReleases;
 
     beforeEach(async () => {
+        issues = someIssues();
         releases = someReleases();
 
         await new HandleRelease(
             releases,
-            aRecordedDecision(aDecisionToRelease({ shouldCreateRelease: false })),
-            someIssues(),
+            aRecordedDecision(aDecisionToRelease({ releaseNotes: '- Fixed the thing (#123)' })),
+            issues,
             anActionContext(),
-            new RecordingLogger()).run();
+            new RecordingLogger(),
+            false).run();
     });
 
-    it('should not create a release', () => {
-        releases.create.called.should.be.false;
+    it('should close nothing', () => {
+        issues.close.called.should.be.false;
+    });
+
+    it('should still create the release', () => {
+        releases.create.calledOnce.should.be.true;
     });
 });

--- a/Source/for_HandleRelease/when_running/with_release_notes_naming_no_issues.ts
+++ b/Source/for_HandleRelease/when_running/with_release_notes_naming_no_issues.ts
@@ -1,0 +1,27 @@
+import { beforeEach, describe, it } from 'vitest';
+
+import { HandleRelease } from '../../HandleRelease';
+import { RecordingLogger } from '../../specs/RecordingLogger';
+import { anActionContext } from '../../specs/anActionContext';
+import { StubbedIssues, someIssues } from '../../specs/someIssues';
+import { someReleases } from '../../specs/someReleases';
+import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
+
+describe('when running the post step with release notes naming no issues', () => {
+    let issues: StubbedIssues;
+
+    beforeEach(async () => {
+        issues = someIssues();
+
+        await new HandleRelease(
+            someReleases(),
+            aRecordedDecision(aDecisionToRelease({ releaseNotes: '- Fixed the thing' })),
+            issues,
+            anActionContext(),
+            new RecordingLogger()).run();
+    });
+
+    it('should close nothing', () => {
+        issues.close.called.should.be.false;
+    });
+});

--- a/Source/for_HandleRelease/when_running/with_release_notes_naming_resolved_issues.ts
+++ b/Source/for_HandleRelease/when_running/with_release_notes_naming_resolved_issues.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, it } from 'vitest';
+
+import { HandleRelease } from '../../HandleRelease';
+import { RecordingLogger } from '../../specs/RecordingLogger';
+import { anActionContext } from '../../specs/anActionContext';
+import { StubbedIssues, someIssues } from '../../specs/someIssues';
+import { someReleases } from '../../specs/someReleases';
+import { aDecisionToRelease, aRecordedDecision } from '../given/a_recorded_decision';
+
+describe('when running the post step with release notes naming resolved issues', () => {
+    let issues: StubbedIssues;
+
+    beforeEach(async () => {
+        issues = someIssues();
+
+        await new HandleRelease(
+            someReleases(),
+            aRecordedDecision(aDecisionToRelease({ releaseNotes: '- Fixed the thing (#123)\n- And another (#456)\n- Mentions #789 in passing' })),
+            issues,
+            anActionContext(),
+            new RecordingLogger()).run();
+    });
+
+    it('should close every issue the notes say the release resolves', () => {
+        issues.close.callCount.should.equal(2);
+    });
+
+    it('should close the first of them', () => {
+        issues.close.firstCall.args[0].should.equal(123);
+    });
+
+    it('should close the second of them', () => {
+        issues.close.secondCall.args[0].should.equal(456);
+    });
+
+    it('should say which release closed it', () => {
+        issues.close.firstCall.args[1].should.contain('v1.2.4');
+    });
+});

--- a/Source/for_HandleRelease/when_running/without_a_recorded_decision.ts
+++ b/Source/for_HandleRelease/when_running/without_a_recorded_decision.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, it } from 'vitest';
 import { HandleRelease } from '../../HandleRelease';
 import { RecordingLogger } from '../../specs/RecordingLogger';
 import { anActionContext } from '../../specs/anActionContext';
+import { someIssues } from '../../specs/someIssues';
 import { StubbedReleases, someReleases } from '../../specs/someReleases';
 import { aRecordedDecision } from '../given/a_recorded_decision';
 
@@ -16,6 +17,7 @@ describe('when running the post step without a recorded decision', () => {
         await new HandleRelease(
             releases,
             aRecordedDecision(undefined),
+            someIssues(),
             anActionContext(),
             new RecordingLogger()).run();
     });

--- a/Source/for_HandleVersion/given/the_main_step.ts
+++ b/Source/for_HandleVersion/given/the_main_step.ts
@@ -18,7 +18,8 @@ export const noInputs: IInputs = {
     tagPrefix: 'v',
     majorLabels: ['major'],
     minorLabels: ['minor'],
-    patchLabels: ['patch']
+    patchLabels: ['patch'],
+    closeResolvedIssues: true
 };
 
 /**

--- a/Source/for_ResolvedIssues/when_reading_release_notes.ts
+++ b/Source/for_ResolvedIssues/when_reading_release_notes.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'vitest';
+
+import { ResolvedIssues } from '../ResolvedIssues';
+
+describe('when reading which issues release notes resolve', () => {
+
+    it('should read the issue a bullet ends with', () => {
+        ResolvedIssues.in('- Fixed the thing (#123)').should.eql([123]);
+    });
+
+    it('should read every bullet in the notes', () => {
+        ResolvedIssues.in('## Fixed\n\n- One (#1)\n- Two (#22)\n').should.eql([1, 22]);
+    });
+
+    it('should read an issue named twice only once', () => {
+        ResolvedIssues.in('- One (#7)\n- Also one (#7)').should.eql([7]);
+    });
+
+    it('should order them ascending however the notes order them', () => {
+        ResolvedIssues.in('- Later (#90)\n- Earlier (#9)').should.eql([9, 90]);
+    });
+
+    // The distinction the whole feature rests on: a release delivers what a bullet ends with, and merely talks
+    // about what prose mentions. Closing on prose would close issues a release only refers to.
+    it('should not read an issue a sentence merely mentions', () => {
+        ResolvedIssues.in('- Fixed the thing, see #123 for background').should.eql([]);
+    });
+
+    it('should not read an issue named as a dependency', () => {
+        ResolvedIssues.in('- Fixed the thing. Related: #123, blocked on #456').should.eql([]);
+    });
+
+    // Another repository's issue is neither this action's to close nor within its token's reach.
+    it('should not read an issue in another repository', () => {
+        ResolvedIssues.in('- Fixed the thing (Cratis/Screenplay#32)').should.eql([]);
+    });
+
+    it('should not read a number that is not an issue', () => {
+        ResolvedIssues.in('- Fixed the thing (#0)').should.eql([]);
+    });
+
+    it('should read nothing from notes that name no issue', () => {
+        ResolvedIssues.in('- Fixed the thing').should.eql([]);
+    });
+
+    it('should read nothing from empty notes', () => {
+        ResolvedIssues.in('').should.eql([]);
+    });
+});

--- a/Source/for_ResolvedIssues/when_reading_release_notes.ts
+++ b/Source/for_ResolvedIssues/when_reading_release_notes.ts
@@ -46,4 +46,18 @@ describe('when reading which issues release notes resolve', () => {
     it('should read nothing from empty notes', () => {
         ResolvedIssues.in('').should.eql([]);
     });
+
+    // Notes that document this very feature write the form out to explain it. Reading a reference that is being
+    // shown rather than made would close whatever issue the example's number happens to name.
+    it('should not read a reference shown inside inline code', () => {
+        ResolvedIssues.in('- Only a bullet ending in `(#123)` counts').should.eql([]);
+    });
+
+    it('should not read a reference shown inside a fenced block', () => {
+        ResolvedIssues.in('- Added the thing (#7)\n\n```markdown\n- Fixed it (#123)\n```\n').should.eql([7]);
+    });
+
+    it('should still read a real reference on a line that also carries code', () => {
+        ResolvedIssues.in('- Renamed `IObserver` to `IReactor` (#42)').should.eql([42]);
+    });
 });

--- a/Source/inputs.ts
+++ b/Source/inputs.ts
@@ -37,5 +37,11 @@ export const inputs: IInputs = {
 
     get patchLabels() {
         return parseLabels(getInput('patch-labels'), 'patch');
+    },
+
+    get closeResolvedIssues() {
+        // Absent means on. The references are already in the notes and already mean "this release delivers
+        // that issue", so the useful default is to act on them; a repository that does not want it says so.
+        return getInput('close-resolved-issues').trim().toLowerCase() !== 'false';
     }
 };

--- a/Source/post.ts
+++ b/Source/post.ts
@@ -3,6 +3,7 @@ import { context } from '@actions/github';
 import { Octokit } from '@octokit/rest';
 
 import { HandleRelease } from './HandleRelease';
+import { Issues } from './Issues';
 import { ReleaseDecisions } from './ReleaseDecisions';
 import { Releases } from './Releases';
 import { inputs } from './inputs';
@@ -16,8 +17,10 @@ const run = async (): Promise<void> => {
     const handleRelease = new HandleRelease(
         new Releases(octokit, context, logger, inputs.tagPrefix),
         new ReleaseDecisions(),
+        new Issues(octokit, context, logger),
         context,
-        logger);
+        logger,
+        inputs.closeResolvedIssues);
 
     await handleRelease.run();
 };

--- a/Source/specs/someIssues.ts
+++ b/Source/specs/someIssues.ts
@@ -1,0 +1,14 @@
+import sinon, { SinonStub } from 'sinon';
+
+import { IIssues } from '../IIssues';
+
+export type StubbedIssues = IIssues & {
+    close: SinonStub;
+};
+
+/**
+ * Builds stubbed issues for a spec, with every close succeeding.
+ */
+export const someIssues = (): StubbedIssues => ({
+    close: sinon.stub().resolves(true)
+});

--- a/action.yml
+++ b/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: "Comma-separated label names that mean a patch version bump."
     required: false
     default: "patch"
+  close-resolved-issues:
+    description: "Whether to close the issues the release notes name as resolved. Only the trailing parenthesized form is read - a note bullet ending in '(#123)'. Prose mentions and cross-repository references are left alone. Set to 'false' to turn it off. Needs a token with 'issues: write'."
+    required: false
+    default: "true"
 
 outputs:
   should-publish:

--- a/dist/main/index.js
+++ b/dist/main/index.js
@@ -40224,6 +40224,11 @@ const inputs = {
     },
     get patchLabels() {
         return parseLabels(getInput('patch-labels'), 'patch');
+    },
+    get closeResolvedIssues() {
+        // Absent means on. The references are already in the notes and already mean "this release delivers
+        // that issue", so the useful default is to act on them; a repository that does not want it says so.
+        return getInput('close-resolved-issues').trim().toLowerCase() !== 'false';
     }
 };
 

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -39616,7 +39616,48 @@ const dist_src_Octokit = Octokit.plugin(requestLog, legacyRestEndpointMethods, p
 );
 
 
+;// CONCATENATED MODULE: ./Source/ResolvedIssues.ts
+/**
+ * The issue numbers a set of release notes says the release resolves.
+ *
+ * Only the trailing parenthesized form the pull request template mandates is read - a bullet ends with the issue
+ * it delivers, as in `- Fixed the thing (#123)`. Prose refers to issues without parentheses ("see #123", "related
+ * to #123", "blocked on #123"), and reading those would close issues a release merely mentions. The parentheses
+ * are what distinguishes "this bullet delivers that issue" from "this bullet talks about it", so they are the
+ * whole of the contract and nothing looser is accepted.
+ *
+ * Cross-repository references (`Cratis/Screenplay#32`) are deliberately not read. They are common in these notes
+ * and they name an issue in another repository, which this action has neither the token scope nor the business to
+ * close.
+ */
+class ResolvedIssues {
+    // A '#' preceded by anything other than '(' is prose, and an owner/repo prefix makes it another repository's
+    // issue. Both are excluded by requiring the '(' to sit immediately before the '#'.
+    static reference = /(?<![\w/-])\(#(\d+)\)/g;
+    /**
+     * Gets the issue numbers the notes say the release resolves, in ascending order and without duplicates.
+     * @param notes The release notes to read.
+     * @returns The issue numbers.
+     */
+    static in(notes) {
+        if (!notes) {
+            return [];
+        }
+        const found = new Set();
+        for (const match of notes.matchAll(ResolvedIssues.reference)) {
+            const number = Number(match[1]);
+            // '(#0)' is not an issue, and a number this large is a typo rather than a reference - closing on
+            // either would act on something the author did not name.
+            if (Number.isSafeInteger(number) && number > 0) {
+                found.add(number);
+            }
+        }
+        return [...found].sort((left, right) => left - right);
+    }
+}
+
 ;// CONCATENATED MODULE: ./Source/HandleRelease.ts
+
 /**
  * The post step of the action. Creates the GitHub release for the decision the main step recorded.
  *
@@ -39626,13 +39667,17 @@ const dist_src_Octokit = Octokit.plugin(requestLog, legacyRestEndpointMethods, p
 class HandleRelease {
     _releases;
     _decisions;
+    _issues;
     _context;
     _logger;
-    constructor(_releases, _decisions, _context, _logger) {
+    _closeResolvedIssues;
+    constructor(_releases, _decisions, _issues, _context, _logger, _closeResolvedIssues = true) {
         this._releases = _releases;
         this._decisions = _decisions;
+        this._issues = _issues;
         this._context = _context;
         this._logger = _logger;
+        this._closeResolvedIssues = _closeResolvedIssues;
     }
     async run() {
         const decision = this._decisions.read();
@@ -39669,6 +39714,66 @@ class HandleRelease {
             targetCommitish
         });
         this._logger.info('GitHub release created.');
+        await this.closeResolvedIssues(decision);
+    }
+    /**
+     * Closes the issues the release notes say this release resolves.
+     *
+     * Done after the release exists, and never allowed to fail the step. The release is the thing that had to
+     * happen; an issue left open because the API refused is a tidiness problem, while a step that fails after
+     * publishing makes the run look as though nothing shipped.
+     */
+    async closeResolvedIssues(decision) {
+        if (!this._closeResolvedIssues) {
+            return;
+        }
+        const resolved = ResolvedIssues.in(decision.releaseNotes);
+        if (resolved.length === 0) {
+            return;
+        }
+        this._logger.info(`The release notes name ${resolved.length} issue(s) as resolved: ${resolved.map(_ => `#${_}`).join(', ')}.`);
+        for (const issue of resolved) {
+            try {
+                const closed = await this._issues.close(issue, `Closed by release **${decision.tag}**.`);
+                if (closed) {
+                    this._logger.info(`Closed #${issue}.`);
+                }
+            }
+            catch (ex) {
+                this._logger.warn(`Could not close #${issue} - leaving it open.`);
+                this._logger.warn(ex);
+            }
+        }
+    }
+}
+
+;// CONCATENATED MODULE: ./Source/Issues.ts
+class Issues {
+    _octokit;
+    _context;
+    _logger;
+    constructor(_octokit, _context, _logger) {
+        this._octokit = _octokit;
+        this._context = _context;
+        this._logger = _logger;
+    }
+    async close(number, comment) {
+        const { owner, repo } = this._context.repo;
+        // Asked for first so that an issue somebody already closed by hand is left exactly as they left it,
+        // rather than gaining a comment saying a release closed it. A pull request shares the issue number
+        // space and is excluded for the same reason - a release does not close a pull request.
+        const existing = await this._octokit.rest.issues.get({ owner, repo, issue_number: number });
+        if (existing.data.state !== 'open') {
+            this._logger.info(`Issue #${number} is already closed - leaving it alone.`);
+            return false;
+        }
+        if (existing.data.pull_request) {
+            this._logger.info(`#${number} is a pull request rather than an issue - leaving it alone.`);
+            return false;
+        }
+        await this._octokit.rest.issues.createComment({ owner, repo, issue_number: number, body: comment });
+        await this._octokit.rest.issues.update({ owner, repo, issue_number: number, state: 'closed', state_reason: 'completed' });
+        return true;
     }
 }
 
@@ -39855,6 +39960,11 @@ const inputs = {
     },
     get patchLabels() {
         return parseLabels(getInput('patch-labels'), 'patch');
+    },
+    get closeResolvedIssues() {
+        // Absent means on. The references are already in the notes and already mean "this release delivers
+        // that issue", so the useful default is to act on them; a repository that does not want it says so.
+        return getInput('close-resolved-issues').trim().toLowerCase() !== 'false';
     }
 };
 
@@ -39897,11 +40007,12 @@ const logger = {
 
 
 
+
 const run = async () => {
     // GITHUB_API_URL is always set by the runner (to https://api.github.com on github.com, or the enterprise
     // host on GitHub Enterprise Server), so honoring it keeps the action working on both.
     const octokit = new dist_src_Octokit({ auth: inputs.gitHubToken || undefined, baseUrl: process.env.GITHUB_API_URL || undefined });
-    const handleRelease = new HandleRelease(new Releases(octokit, github_context, logger, inputs.tagPrefix), new ReleaseDecisions(), github_context, logger);
+    const handleRelease = new HandleRelease(new Releases(octokit, github_context, logger, inputs.tagPrefix), new ReleaseDecisions(), new Issues(octokit, github_context, logger), github_context, logger, inputs.closeResolvedIssues);
     await handleRelease.run();
 };
 run().catch(ex => setFailed(ex instanceof Error ? ex : String(ex)));

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -39634,6 +39634,12 @@ class ResolvedIssues {
     // A '#' preceded by anything other than '(' is prose, and an owner/repo prefix makes it another repository's
     // issue. Both are excluded by requiring the '(' to sit immediately before the '#'.
     static reference = /(?<![\w/-])\(#(\d+)\)/g;
+    // Release notes carry code - a fenced example of a workflow, an inline mention of the very syntax this class
+    // reads. A reference written inside either is being shown, not made, and closing on it would close whatever
+    // issue the example's number happens to name. The notes of this feature's own release are the proof: they
+    // document the form by writing `(#123)`, and #123 in this repository is an unrelated dependency bump.
+    static fencedCode = /^[ \t]*(`{3,}|~{3,})[\s\S]*?^[ \t]*\1[ \t]*$/gm;
+    static inlineCode = /(`+)[^\n]*?\1/g;
     /**
      * Gets the issue numbers the notes say the release resolves, in ascending order and without duplicates.
      * @param notes The release notes to read.
@@ -39643,8 +39649,11 @@ class ResolvedIssues {
         if (!notes) {
             return [];
         }
+        const prose = notes
+            .replace(ResolvedIssues.fencedCode, '')
+            .replace(ResolvedIssues.inlineCode, '');
         const found = new Set();
-        for (const match of notes.matchAll(ResolvedIssues.reference)) {
+        for (const match of prose.matchAll(ResolvedIssues.reference)) {
             const number = Number(match[1]);
             // '(#0)' is not an issue, and a number this large is a typo rather than a reference - closing on
             // either would act on something the author did not name.


### PR DESCRIPTION
## Added

- The issues a release's notes say it resolves are closed when the release is created, each with a comment naming the release tag. Only a note bullet ending in `(#123)` counts; prose mentions and cross-repository references are left alone. Needs `issues: write`, and is turned off with `close-resolved-issues: false`
